### PR TITLE
setStateに空のオブジェクトを渡すことで再描画を矯正する

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,14 +1,26 @@
-import React, { useState, FC } from "react";
+import React, { useState, FC, useRef } from "react";
 import ShowStatus from "./ShowStatus";
 import ShowLevel from "./ShowLevel";
 import Board from "./Board";
 import GameController from "./GameControler";
 import Puzzle from "../util/puzzle";
 
+/**
+ * 強制的に再描画する関数を返すカスタムhook
+ */
+const useForceRender = () => {
+  // つかわないのでアンスコにしている
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_, set] = useState({});
+  return () => set({});
+}
+
 // メインのゲームコンポーネント
 const Game: FC = () => {
+  const forceRender = useForceRender();
   // 盤面数設定
-  const [puzzle, setPuzzle] = useState(new Puzzle(9));
+  const puzzleRef = useRef<Puzzle>(new Puzzle(9));
+  const puzzle = puzzleRef.current;
   // 初期データセット
   const answerDatas = puzzle.answerDatas;
   const gameDatas = puzzle.gameDatas;
@@ -28,19 +40,12 @@ const Game: FC = () => {
       puzzle.generateGameDatas();
       // 動かせるセルをセット
       puzzle.setMove();
-      // セット
-      // useStateはイミュータブルじゃないとダメ
-      // とりあえず今はインスタンスをコピーしてお茶を濁す
-      const clone = Object.assign(
-        Object.create(Object.getPrototypeOf(puzzle)),
-        puzzle
-      );
-      setPuzzle(clone);
     } else {
       // ギブアップ
       // ゲーム初期化
-      setPuzzle(new Puzzle(9));
+      puzzleRef.current = new Puzzle(9);
     }
+    forceRender();
   };
   // 空白セルクリックハンドラ
   const handleLink = (
@@ -51,14 +56,7 @@ const Game: FC = () => {
     event.preventDefault();
     // 空白セルを動かす
     puzzle.move(moveIndex);
-    // セット
-    // useStateはイミュータブルじゃないとダメ
-    // とりあえず今はインスタンスをコピーしてお茶を濁す
-    const clone = Object.assign(
-      Object.create(Object.getPrototypeOf(puzzle)),
-      puzzle
-    );
-    setPuzzle(clone);
+    forceRender();
     // ゲームがクリアされていなければ、次の動かせるセルをセットする
     if (!puzzle.isComplete()) {
       // 動かせるセルをセット


### PR DESCRIPTION
さすがに puzzle インスタンスを無理やりcloneするのは見通しが悪いので、再描画用にstateをつくってそのstateを更新することで再描画を矯正するようにした。
puzzleインスタンスはrefを使うことでアクセスできるようにした。
再描画するための関数は目的が明確なのでついでにカスタムhookにした。

## refとは?

雑に言うとインスタンス変数のようにつかえるもの。
コンポーネントを再描画したときでも、常に同じ参照を指すことが保証されている。
useRefで渡した引数は初期値で、currentプロパティに保持される。